### PR TITLE
Set country as "FR" for overseas departements

### DIFF
--- a/modules/registrars/gandiv5/lib/ApiClient.php
+++ b/modules/registrars/gandiv5/lib/ApiClient.php
@@ -39,6 +39,10 @@ class ApiClient
             "type" => 0, // 0=person, 1=company, 2=association, 3=public body, 4=reseller
             "email" => $contacts["owner"]["email"]
         ];
+        if (in_array($owner['country'], ['GF', 'GP', 'MQ', 'RE', 'YT'])) {
+            $owner['state'] = 'FR-'.$owner['country'];
+            $owner['country'] = 'FR';
+        }
         $params = [
             "fqdn" => $domain,
             "duration" => $period,
@@ -73,6 +77,10 @@ class ApiClient
             "type" => 0, // 0=person, 1=company, 2=association, 3=public body, 4=reseller
             "email" => $contacts["owner"]["email"]
         ];
+        if (in_array($owner['country'], ['GF', 'GP', 'MQ', 'RE', 'YT'])) {
+            $owner['state'] = 'FR-'.$owner['country'];
+            $owner['country'] = 'FR';
+        }
         $params = [
             "fqdn" => $domain,
             "duration" => $period,


### PR DESCRIPTION
If you set the country-code to the corresponding overseas departement (eg. `RE`), Gandi API will reject registration/transfer:

```
{"status":"error","errors":[{"name":"owner.country","location":"body","description":"RE
is not a country that is authorized for this extension"}]}
```

This merge request allows to send the expected country-code (`FR`) and state (eg. `FR-RE`) expected by Gandi API.

More information on Gandi ticket `#15030076`.
