### PR TITLE
Pass correct language to Gandi API - fixes Gandi/whmcs_Gandi-module#11

### DIFF
--- a/modules/registrars/gandiv5/gandiv5.php
+++ b/modules/registrars/gandiv5/gandiv5.php
@@ -144,7 +144,8 @@ function gandiv5_RegisterDomain($params)
         "phonenumber" => $params["phonenumber"],
         "phonecountrcCode" => $params["phonecc"],
         "phonenumberformatted" => $params['phonenumberformatted'],
-        "orgname" => $params['companyname']
+        "orgname" => $params['companyname'],
+        "language" => (empty($params['language'])) ? $GLOBALS['CONFIG']['Language'] : $params['language']
     ];
     $apiKey = $params['API Key'];
     $registrationPeriod = $params['regperiod'];
@@ -208,7 +209,8 @@ function gandiv5_TransferDomain($params)
         "phonenumber" => $params["phonenumber"],
         "phonecountrcCode" => $params["phonecc"],
         "phonenumberformatted" => $params['phonenumberformatted'],
-        "orgname" => $params['companyname']
+        "orgname" => $params['companyname'],
+        "language" => (empty($params['language'])) ? $GLOBALS['CONFIG']['Language'] : $params['language']
     ];
 
     if( $params['accountType'] == 'individual' ){

--- a/modules/registrars/gandiv5/lib/ApiClient.php
+++ b/modules/registrars/gandiv5/lib/ApiClient.php
@@ -76,6 +76,16 @@ class ApiClient
     }
 
     private function generateOwner($domain, $contacts) {
+
+        // One of: "en", "es", "fr", "ja", "zh-hans", "zh-hant"
+        $languages_mapping = [
+            'english' => 'en',
+            'spanish' => 'es',
+            'french' => 'fr',
+            'japanese' => 'ja',
+            'chinese' => 'zh-hant',
+        ];
+
         $owner = [
             "city" => $contacts["owner"]["city"],
             "orgname" => $contacts["owner"]["orgname"],
@@ -92,6 +102,9 @@ class ApiClient
         if (in_array($owner['country'], ['GF', 'GP', 'MQ', 'RE', 'YT'])) {
             $owner['state'] = 'FR-'.$owner['country'];
             $owner['country'] = 'FR';
+        }
+        if (isset($languages_mapping[$contacts["owner"]["language"]])) {
+         $owner['lang'] = $languages_mapping[$contacts["owner"]["language"]];
         }
         return $owner;
     }


### PR DESCRIPTION
The WHMCS module didn't pass the user language, this PR fixes that. If the user has set a language, we use his/her language; else we use WHMCS default language.